### PR TITLE
style: 강의 정보 표시 스타일 개선 및 여백 조정

### DIFF
--- a/src/components/TimeTable/index.tsx
+++ b/src/components/TimeTable/index.tsx
@@ -186,7 +186,7 @@ export const TimeTable: React.FC<TimeTableProps> = ({ courses, activeCourseId })
               <div
                 key={`${course.courseId}-${courseTime.dayOfWeek}-${index}`}
                 className={cn(
-                  `p-2 flex flex-col overflow-hidden transition-opacity duration-300`,
+                  `p-2 flex flex-col overflow-scroll transition-opacity duration-300 no-scollbar`,
                   fontStyles.caption,
                   !isActive && "opacity-30"
                 )}
@@ -197,12 +197,12 @@ export const TimeTable: React.FC<TimeTableProps> = ({ courses, activeCourseId })
                 }}
               >
                 {/* 수업 이름 */}
-                <p className="text-lg leading-none overflow-hidden text-ellipsis w-full mb-1">{course.courseName}</p>
+                <p className="text-lg leading-none w-full mb-1">{course.courseName}</p>
                 {/* 교수명 */}
-                <p className="font-bold overflow-hidden text-ellipsis w-full mb-1">{course.professor}</p>
+                <p className="font-bold w-full mb-1">{course.professor}</p>
                 {/* 강의실 위치 */}
                 {courseTime.classroom && (
-                  <p className="overflow-hidden w-full">{courseTime.classroom}</p>
+                  <p className="w-full">{courseTime.classroom}</p>
                 )}
               </div>
             );


### PR DESCRIPTION
# 강의 정보 표시 스타일 개선 및 여백 조정

## 변경사항

- 에 모 앱, u 모 프로그램과 같이 시간표가 좌측 상단에서 순차적으로 정렬되어 출력되도록 수정
- 강의명이나 강의실 위치의 nowrap 속성 제외하여 두 줄 이상도 출력 가능하도록 변경

## 스크린샷

| 기존 | 수정 |
|-|-|
| <img width="1086" height="876" alt="image" src="https://github.com/user-attachments/assets/070b632c-6a2a-4b06-9410-2c5e0c7e31f8" /> | <img width="1089" height="877" alt="image" src="https://github.com/user-attachments/assets/02a5ad52-dc8a-419d-884e-d0d97f7a1da1" /> |


## 수정된 파일
- `src/components/TimeTable/index.tsx`
